### PR TITLE
Adjust patch offsets for undub file merging

### DIFF
--- a/patch_mixer_20250806_125917.log
+++ b/patch_mixer_20250806_125917.log
@@ -1,0 +1,305 @@
+2025-08-06 12:59:17,748 - INFO - === Smart Patch Mixer Started ===
+2025-08-06 12:59:17,748 - INFO - Log file: patch_mixer_20250806_125917.log
+2025-08-06 12:59:17,748 - INFO - Found files:
+2025-08-06 12:59:17,749 - INFO -   Original: FDAT.T
+2025-08-06 12:59:17,749 - INFO -   True Analog: FDAT.T
+2025-08-06 12:59:17,749 - INFO -   Undub: FDAT.T
+2025-08-06 12:59:17,749 - INFO - Loading files...
+2025-08-06 12:59:17,814 - INFO - Original: 17715200 bytes
+2025-08-06 12:59:17,814 - INFO - True Analog: 17715200 bytes
+2025-08-06 12:59:17,814 - INFO - Undub: 18024448 bytes
+2025-08-06 12:59:17,814 - INFO - Analyzing True Analog differences...
+2025-08-06 12:59:18,465 - INFO - Found 71 True Analog differences
+2025-08-06 12:59:18,465 - INFO - Creating mixed file from undub base...
+2025-08-06 12:59:18,483 - INFO - Processing patch at 0xFB7708: 0x87 -> 0x3C
+2025-08-06 12:59:19,447 - INFO - Found context match: 0xFB7708 -> 0x1002F08 (diff: +309248)
+2025-08-06 12:59:19,447 - INFO - ✓ Validated patch location 0x1002F08
+2025-08-06 12:59:19,447 - INFO - ✓ Applied patch: 0xFB7708 -> 0x1002F08
+2025-08-06 12:59:19,447 - INFO - Processing patch at 0xFB7709: 0x5D -> 0x45
+2025-08-06 12:59:20,436 - INFO - Found context match: 0xFB7709 -> 0x1002F09 (diff: +309248)
+2025-08-06 12:59:20,436 - INFO - ✓ Validated patch location 0x1002F09
+2025-08-06 12:59:20,436 - INFO - ✓ Applied patch: 0xFB7709 -> 0x1002F09
+2025-08-06 12:59:20,436 - INFO - Processing patch at 0xFB77F0: 0xD2 -> 0x1B
+2025-08-06 12:59:21,409 - INFO - Found context match: 0xFB77F0 -> 0x1002FF0 (diff: +309248)
+2025-08-06 12:59:21,409 - INFO - ✓ Validated patch location 0x1002FF0
+2025-08-06 12:59:21,409 - INFO - ✓ Applied patch: 0xFB77F0 -> 0x1002FF0
+2025-08-06 12:59:21,409 - INFO - Processing patch at 0xFB77F1: 0xFC -> 0x45
+2025-08-06 12:59:22,383 - INFO - Found context match: 0xFB77F1 -> 0x1002FF1 (diff: +309248)
+2025-08-06 12:59:22,383 - INFO - ✓ Validated patch location 0x1002FF1
+2025-08-06 12:59:22,383 - INFO - ✓ Applied patch: 0xFB77F1 -> 0x1002FF1
+2025-08-06 12:59:22,383 - INFO - Processing patch at 0xFB77F2: 0x01 -> 0x00
+2025-08-06 12:59:23,337 - INFO - Found context match: 0xFB77F2 -> 0x1002FF2 (diff: +309248)
+2025-08-06 12:59:23,338 - INFO - ✓ Validated patch location 0x1002FF2
+2025-08-06 12:59:23,338 - INFO - ✓ Applied patch: 0xFB77F2 -> 0x1002FF2
+2025-08-06 12:59:23,338 - INFO - Processing patch at 0xFB7B54: 0xCF -> 0x04
+2025-08-06 12:59:24,321 - INFO - Found context match: 0xFB7B54 -> 0x1003354 (diff: +309248)
+2025-08-06 12:59:24,321 - INFO - ✓ Validated patch location 0x1003354
+2025-08-06 12:59:24,321 - INFO - ✓ Applied patch: 0xFB7B54 -> 0x1003354
+2025-08-06 12:59:24,321 - INFO - Processing patch at 0xFB7B55: 0xFD -> 0x46
+2025-08-06 12:59:25,259 - INFO - Found context match: 0xFB7B55 -> 0x1003355 (diff: +309248)
+2025-08-06 12:59:25,259 - INFO - ✓ Validated patch location 0x1003355
+2025-08-06 12:59:25,259 - INFO - ✓ Applied patch: 0xFB7B55 -> 0x1003355
+2025-08-06 12:59:25,259 - INFO - Processing patch at 0xFB7B56: 0x01 -> 0x00
+2025-08-06 12:59:26,171 - INFO - Found context match: 0xFB7B56 -> 0x1003356 (diff: +309248)
+2025-08-06 12:59:26,172 - INFO - ✓ Validated patch location 0x1003356
+2025-08-06 12:59:26,172 - INFO - ✓ Applied patch: 0xFB7B56 -> 0x1003356
+2025-08-06 12:59:26,172 - INFO - Processing patch at 0xFB7E14: 0xCF -> 0x04
+2025-08-06 12:59:27,089 - INFO - Found context match: 0xFB7E14 -> 0x1003614 (diff: +309248)
+2025-08-06 12:59:27,089 - INFO - ✓ Validated patch location 0x1003614
+2025-08-06 12:59:27,089 - INFO - ✓ Applied patch: 0xFB7E14 -> 0x1003614
+2025-08-06 12:59:27,089 - INFO - Processing patch at 0xFB7E15: 0xFD -> 0x46
+2025-08-06 12:59:28,001 - INFO - Found context match: 0xFB7E15 -> 0x1003615 (diff: +309248)
+2025-08-06 12:59:28,001 - INFO - ✓ Validated patch location 0x1003615
+2025-08-06 12:59:28,001 - INFO - ✓ Applied patch: 0xFB7E15 -> 0x1003615
+2025-08-06 12:59:28,001 - INFO - Processing patch at 0xFB7E16: 0x01 -> 0x00
+2025-08-06 12:59:28,874 - INFO - Found context match: 0xFB7E16 -> 0x1003616 (diff: +309248)
+2025-08-06 12:59:28,874 - INFO - ✓ Validated patch location 0x1003616
+2025-08-06 12:59:28,874 - INFO - ✓ Applied patch: 0xFB7E16 -> 0x1003616
+2025-08-06 12:59:28,874 - INFO - Processing patch at 0xFB7E78: 0xCF -> 0x04
+2025-08-06 12:59:29,752 - INFO - Found context match: 0xFB7E78 -> 0x1003614 (diff: +309148)
+2025-08-06 12:59:29,752 - INFO - ✓ Validated patch location 0x1003614
+2025-08-06 12:59:29,752 - INFO - ✓ Applied patch: 0xFB7E78 -> 0x1003614
+2025-08-06 12:59:29,752 - INFO - Processing patch at 0xFB7E79: 0xFD -> 0x46
+2025-08-06 12:59:30,632 - INFO - Found context match: 0xFB7E79 -> 0x1003615 (diff: +309148)
+2025-08-06 12:59:30,632 - INFO - ✓ Validated patch location 0x1003615
+2025-08-06 12:59:30,632 - INFO - ✓ Applied patch: 0xFB7E79 -> 0x1003615
+2025-08-06 12:59:30,632 - INFO - Processing patch at 0xFB7E7A: 0x01 -> 0x00
+2025-08-06 12:59:31,526 - INFO - Found context match: 0xFB7E7A -> 0x1003616 (diff: +309148)
+2025-08-06 12:59:31,526 - INFO - ✓ Validated patch location 0x1003616
+2025-08-06 12:59:31,526 - INFO - ✓ Applied patch: 0xFB7E7A -> 0x1003616
+2025-08-06 12:59:31,526 - INFO - Processing patch at 0xFB7FA8: 0x26 -> 0xBF
+2025-08-06 12:59:32,412 - INFO - Found context match: 0xFB7FA8 -> 0x10037A8 (diff: +309248)
+2025-08-06 12:59:32,412 - INFO - ✓ Validated patch location 0x10037A8
+2025-08-06 12:59:32,413 - INFO - ✓ Applied patch: 0xFB7FA8 -> 0x10037A8
+2025-08-06 12:59:32,413 - INFO - Processing patch at 0xFB7FA9: 0xFF -> 0x44
+2025-08-06 12:59:33,278 - INFO - Found context match: 0xFB7FA9 -> 0x10037A9 (diff: +309248)
+2025-08-06 12:59:33,279 - INFO - ✓ Validated patch location 0x10037A9
+2025-08-06 12:59:33,279 - INFO - ✓ Applied patch: 0xFB7FA9 -> 0x10037A9
+2025-08-06 12:59:33,279 - INFO - Processing patch at 0xFB7FAA: 0x01 -> 0x00
+2025-08-06 12:59:34,144 - INFO - Found context match: 0xFB7FAA -> 0x10037AA (diff: +309248)
+2025-08-06 12:59:34,144 - INFO - ✓ Validated patch location 0x10037AA
+2025-08-06 12:59:34,144 - INFO - ✓ Applied patch: 0xFB7FAA -> 0x10037AA
+2025-08-06 12:59:34,144 - INFO - Processing patch at 0xFB80AC: 0x66 -> 0xD5
+2025-08-06 12:59:35,008 - INFO - Found context match: 0xFB80AC -> 0x10038AC (diff: +309248)
+2025-08-06 12:59:35,008 - INFO - ✓ Validated patch location 0x10038AC
+2025-08-06 12:59:35,008 - INFO - ✓ Applied patch: 0xFB80AC -> 0x10038AC
+2025-08-06 12:59:35,008 - INFO - Processing patch at 0xFB80AD: 0xFF -> 0x44
+2025-08-06 12:59:35,872 - INFO - Found context match: 0xFB80AD -> 0x10038AD (diff: +309248)
+2025-08-06 12:59:35,872 - INFO - ✓ Validated patch location 0x10038AD
+2025-08-06 12:59:35,872 - INFO - ✓ Applied patch: 0xFB80AD -> 0x10038AD
+2025-08-06 12:59:35,872 - INFO - Processing patch at 0xFB80AE: 0x01 -> 0x00
+2025-08-06 12:59:36,788 - INFO - Found context match: 0xFB80AE -> 0x10038AE (diff: +309248)
+2025-08-06 12:59:36,789 - INFO - ✓ Validated patch location 0x10038AE
+2025-08-06 12:59:36,789 - INFO - ✓ Applied patch: 0xFB80AE -> 0x10038AE
+2025-08-06 12:59:36,789 - INFO - Processing patch at 0xFB80E4: 0xCF -> 0x04
+2025-08-06 12:59:37,653 - INFO - Found context match: 0xFB80E4 -> 0x10038E4 (diff: +309248)
+2025-08-06 12:59:37,653 - INFO - ✓ Validated patch location 0x10038E4
+2025-08-06 12:59:37,653 - INFO - ✓ Applied patch: 0xFB80E4 -> 0x10038E4
+2025-08-06 12:59:37,653 - INFO - Processing patch at 0xFB80E5: 0xFD -> 0x46
+2025-08-06 12:59:38,516 - INFO - Found context match: 0xFB80E5 -> 0x10038E5 (diff: +309248)
+2025-08-06 12:59:38,516 - INFO - ✓ Validated patch location 0x10038E5
+2025-08-06 12:59:38,516 - INFO - ✓ Applied patch: 0xFB80E5 -> 0x10038E5
+2025-08-06 12:59:38,516 - INFO - Processing patch at 0xFB80E6: 0x01 -> 0x00
+2025-08-06 12:59:39,426 - INFO - Found context match: 0xFB80E6 -> 0x10038E6 (diff: +309248)
+2025-08-06 12:59:39,426 - INFO - ✓ Validated patch location 0x10038E6
+2025-08-06 12:59:39,427 - INFO - ✓ Applied patch: 0xFB80E6 -> 0x10038E6
+2025-08-06 12:59:39,427 - INFO - Processing patch at 0xFB93BC: 0xCF -> 0x04
+2025-08-06 12:59:40,293 - INFO - Found context match: 0xFB93BC -> 0x1004BBC (diff: +309248)
+2025-08-06 12:59:40,293 - INFO - ✓ Validated patch location 0x1004BBC
+2025-08-06 12:59:40,293 - INFO - ✓ Applied patch: 0xFB93BC -> 0x1004BBC
+2025-08-06 12:59:40,293 - INFO - Processing patch at 0xFB93BD: 0xFD -> 0x46
+2025-08-06 12:59:41,203 - INFO - Found context match: 0xFB93BD -> 0x1004BBD (diff: +309248)
+2025-08-06 12:59:41,203 - INFO - ✓ Validated patch location 0x1004BBD
+2025-08-06 12:59:41,203 - INFO - ✓ Applied patch: 0xFB93BD -> 0x1004BBD
+2025-08-06 12:59:41,203 - INFO - Processing patch at 0xFB93BE: 0x01 -> 0x00
+2025-08-06 12:59:42,067 - INFO - Found context match: 0xFB93BE -> 0x1004BBE (diff: +309248)
+2025-08-06 12:59:42,067 - INFO - ✓ Validated patch location 0x1004BBE
+2025-08-06 12:59:42,067 - INFO - ✓ Applied patch: 0xFB93BE -> 0x1004BBE
+2025-08-06 12:59:42,067 - INFO - Processing patch at 0xFB97B0: 0xCF -> 0x04
+2025-08-06 12:59:42,954 - INFO - Found context match: 0xFB97B0 -> 0x1004FB0 (diff: +309248)
+2025-08-06 12:59:42,955 - INFO - ✓ Validated patch location 0x1004FB0
+2025-08-06 12:59:42,955 - INFO - ✓ Applied patch: 0xFB97B0 -> 0x1004FB0
+2025-08-06 12:59:42,955 - INFO - Processing patch at 0xFB97B1: 0xFD -> 0x46
+2025-08-06 12:59:43,861 - INFO - Found context match: 0xFB97B1 -> 0x1004FB1 (diff: +309248)
+2025-08-06 12:59:43,862 - INFO - ✓ Validated patch location 0x1004FB1
+2025-08-06 12:59:43,862 - INFO - ✓ Applied patch: 0xFB97B1 -> 0x1004FB1
+2025-08-06 12:59:43,862 - INFO - Processing patch at 0xFB97B2: 0x01 -> 0x00
+2025-08-06 12:59:44,783 - INFO - Found context match: 0xFB97B2 -> 0x1004FB2 (diff: +309248)
+2025-08-06 12:59:44,783 - INFO - ✓ Validated patch location 0x1004FB2
+2025-08-06 12:59:44,783 - INFO - ✓ Applied patch: 0xFB97B2 -> 0x1004FB2
+2025-08-06 12:59:44,783 - INFO - Processing patch at 0xFBEF88: 0xCF -> 0x04
+2025-08-06 12:59:45,707 - INFO - Found context match: 0xFBEF88 -> 0x100A788 (diff: +309248)
+2025-08-06 12:59:45,707 - INFO - ✓ Validated patch location 0x100A788
+2025-08-06 12:59:45,707 - INFO - ✓ Applied patch: 0xFBEF88 -> 0x100A788
+2025-08-06 12:59:45,707 - INFO - Processing patch at 0xFBEF89: 0xFD -> 0x46
+2025-08-06 12:59:46,626 - INFO - Found context match: 0xFBEF89 -> 0x100A789 (diff: +309248)
+2025-08-06 12:59:46,626 - INFO - ✓ Validated patch location 0x100A789
+2025-08-06 12:59:46,626 - INFO - ✓ Applied patch: 0xFBEF89 -> 0x100A789
+2025-08-06 12:59:46,626 - INFO - Processing patch at 0xFBEF8A: 0x01 -> 0x00
+2025-08-06 12:59:47,503 - INFO - Found context match: 0xFBEF8A -> 0x100A78A (diff: +309248)
+2025-08-06 12:59:47,503 - INFO - ✓ Validated patch location 0x100A78A
+2025-08-06 12:59:47,503 - INFO - ✓ Applied patch: 0xFBEF8A -> 0x100A78A
+2025-08-06 12:59:47,503 - INFO - Processing patch at 0xFD0FFC: 0xF9 -> 0x72
+2025-08-06 12:59:48,420 - INFO - Found context match: 0xFD0FFC -> 0x101C7FC (diff: +309248)
+2025-08-06 12:59:48,420 - INFO - ✓ Validated patch location 0x101C7FC
+2025-08-06 12:59:48,421 - INFO - ✓ Applied patch: 0xFD0FFC -> 0x101C7FC
+2025-08-06 12:59:48,421 - INFO - Processing patch at 0xFD0FFD: 0xF9 -> 0xAE
+2025-08-06 12:59:49,339 - INFO - Found context match: 0xFD0FFD -> 0x101C7FD (diff: +309248)
+2025-08-06 12:59:49,339 - INFO - ✓ Validated patch location 0x101C7FD
+2025-08-06 12:59:49,339 - INFO - ✓ Applied patch: 0xFD0FFD -> 0x101C7FD
+2025-08-06 12:59:49,339 - INFO - Processing patch at 0xFD0FFE: 0x0B -> 0xFA
+2025-08-06 12:59:50,267 - INFO - Found context match: 0xFD0FFE -> 0x101C7FE (diff: +309248)
+2025-08-06 12:59:50,267 - INFO - ✓ Validated patch location 0x101C7FE
+2025-08-06 12:59:50,267 - INFO - ✓ Applied patch: 0xFD0FFE -> 0x101C7FE
+2025-08-06 12:59:50,267 - INFO - Processing patch at 0xFD0FFF: 0xB9 -> 0xB8
+2025-08-06 12:59:51,227 - INFO - Found context match: 0xFD0FFF -> 0x101C7FF (diff: +309248)
+2025-08-06 12:59:51,227 - INFO - ✓ Validated patch location 0x101C7FF
+2025-08-06 12:59:51,227 - INFO - ✓ Applied patch: 0xFD0FFF -> 0x101C7FF
+2025-08-06 12:59:51,227 - INFO - Processing patch at 0x10868CC: 0x87 -> 0x3C
+2025-08-06 12:59:52,178 - INFO - Found context match: 0x10868CC -> 0x10D20CC (diff: +309248)
+2025-08-06 12:59:52,178 - INFO - ✓ Validated patch location 0x10D20CC
+2025-08-06 12:59:52,178 - INFO - ✓ Applied patch: 0x10868CC -> 0x10D20CC
+2025-08-06 12:59:52,178 - INFO - Processing patch at 0x10868CD: 0x5D -> 0x45
+2025-08-06 12:59:53,177 - INFO - Found context match: 0x10868CD -> 0x10D20CD (diff: +309248)
+2025-08-06 12:59:53,177 - INFO - ✓ Validated patch location 0x10D20CD
+2025-08-06 12:59:53,177 - INFO - ✓ Applied patch: 0x10868CD -> 0x10D20CD
+2025-08-06 12:59:53,177 - INFO - Processing patch at 0x1086A2C: 0x76 -> 0x22
+2025-08-06 12:59:54,113 - INFO - Found context match: 0x1086A2C -> 0x10D222C (diff: +309248)
+2025-08-06 12:59:54,113 - INFO - ✓ Validated patch location 0x10D222C
+2025-08-06 12:59:54,113 - INFO - ✓ Applied patch: 0x1086A2C -> 0x10D222C
+2025-08-06 12:59:54,113 - INFO - Processing patch at 0x1086A2D: 0xFC -> 0x45
+2025-08-06 12:59:55,059 - INFO - Found context match: 0x1086A2D -> 0x10D222D (diff: +309248)
+2025-08-06 12:59:55,059 - INFO - ✓ Validated patch location 0x10D222D
+2025-08-06 12:59:55,059 - INFO - ✓ Applied patch: 0x1086A2D -> 0x10D222D
+2025-08-06 12:59:55,059 - INFO - Processing patch at 0x1086A2E: 0x01 -> 0x00
+2025-08-06 12:59:55,968 - INFO - Found context match: 0x1086A2E -> 0x10D222E (diff: +309248)
+2025-08-06 12:59:55,969 - INFO - ✓ Validated patch location 0x10D222E
+2025-08-06 12:59:55,969 - INFO - ✓ Applied patch: 0x1086A2E -> 0x10D222E
+2025-08-06 12:59:55,969 - INFO - Processing patch at 0x1086D68: 0x54 -> 0x12
+2025-08-06 12:59:56,874 - INFO - Found context match: 0x1086D68 -> 0x10D2568 (diff: +309248)
+2025-08-06 12:59:56,874 - INFO - ✓ Validated patch location 0x10D2568
+2025-08-06 12:59:56,875 - INFO - ✓ Applied patch: 0x1086D68 -> 0x10D2568
+2025-08-06 12:59:56,875 - INFO - Processing patch at 0x1086D69: 0xFE -> 0x46
+2025-08-06 12:59:57,829 - INFO - Found context match: 0x1086D69 -> 0x10D2569 (diff: +309248)
+2025-08-06 12:59:57,830 - INFO - ✓ Validated patch location 0x10D2569
+2025-08-06 12:59:57,830 - INFO - ✓ Applied patch: 0x1086D69 -> 0x10D2569
+2025-08-06 12:59:57,830 - INFO - Processing patch at 0x1086D6A: 0x01 -> 0x00
+2025-08-06 12:59:58,737 - INFO - Found context match: 0x1086D6A -> 0x10D256A (diff: +309248)
+2025-08-06 12:59:58,737 - INFO - ✓ Validated patch location 0x10D256A
+2025-08-06 12:59:58,737 - INFO - ✓ Applied patch: 0x1086D6A -> 0x10D256A
+2025-08-06 12:59:58,737 - INFO - Processing patch at 0x1087028: 0x54 -> 0x12
+2025-08-06 12:59:59,679 - INFO - Found context match: 0x1087028 -> 0x10D2828 (diff: +309248)
+2025-08-06 12:59:59,679 - INFO - ✓ Validated patch location 0x10D2828
+2025-08-06 12:59:59,679 - INFO - ✓ Applied patch: 0x1087028 -> 0x10D2828
+2025-08-06 12:59:59,679 - INFO - Processing patch at 0x1087029: 0xFE -> 0x46
+2025-08-06 13:00:00,634 - INFO - Found context match: 0x1087029 -> 0x10D2829 (diff: +309248)
+2025-08-06 13:00:00,634 - INFO - ✓ Validated patch location 0x10D2829
+2025-08-06 13:00:00,634 - INFO - ✓ Applied patch: 0x1087029 -> 0x10D2829
+2025-08-06 13:00:00,635 - INFO - Processing patch at 0x108702A: 0x01 -> 0x00
+2025-08-06 13:00:01,544 - INFO - Found context match: 0x108702A -> 0x10D282A (diff: +309248)
+2025-08-06 13:00:01,544 - INFO - ✓ Validated patch location 0x10D282A
+2025-08-06 13:00:01,544 - INFO - ✓ Applied patch: 0x108702A -> 0x10D282A
+2025-08-06 13:00:01,544 - INFO - Processing patch at 0x108708C: 0x54 -> 0x12
+2025-08-06 13:00:02,454 - INFO - Found context match: 0x108708C -> 0x10D2828 (diff: +309148)
+2025-08-06 13:00:02,454 - INFO - ✓ Validated patch location 0x10D2828
+2025-08-06 13:00:02,455 - INFO - ✓ Applied patch: 0x108708C -> 0x10D2828
+2025-08-06 13:00:02,455 - INFO - Processing patch at 0x108708D: 0xFE -> 0x46
+2025-08-06 13:00:03,409 - INFO - Found context match: 0x108708D -> 0x10D2829 (diff: +309148)
+2025-08-06 13:00:03,410 - INFO - ✓ Validated patch location 0x10D2829
+2025-08-06 13:00:03,410 - INFO - ✓ Applied patch: 0x108708D -> 0x10D2829
+2025-08-06 13:00:03,410 - INFO - Processing patch at 0x108708E: 0x01 -> 0x00
+2025-08-06 13:00:04,319 - INFO - Found context match: 0x108708E -> 0x10D282A (diff: +309148)
+2025-08-06 13:00:04,319 - INFO - ✓ Validated patch location 0x10D282A
+2025-08-06 13:00:04,319 - INFO - ✓ Applied patch: 0x108708E -> 0x10D282A
+2025-08-06 13:00:04,319 - INFO - Processing patch at 0x10871BC: 0xAB -> 0xED
+2025-08-06 13:00:05,228 - INFO - Found context match: 0x10871BC -> 0x10D29BC (diff: +309248)
+2025-08-06 13:00:05,228 - INFO - ✓ Validated patch location 0x10D29BC
+2025-08-06 13:00:05,228 - INFO - ✓ Applied patch: 0x10871BC -> 0x10D29BC
+2025-08-06 13:00:05,228 - INFO - Processing patch at 0x10871BD: 0xFF -> 0x44
+2025-08-06 13:00:06,138 - INFO - Found context match: 0x10871BD -> 0x10D29BD (diff: +309248)
+2025-08-06 13:00:06,138 - INFO - ✓ Validated patch location 0x10D29BD
+2025-08-06 13:00:06,138 - INFO - ✓ Applied patch: 0x10871BD -> 0x10D29BD
+2025-08-06 13:00:06,138 - INFO - Processing patch at 0x10871BE: 0x01 -> 0x00
+2025-08-06 13:00:07,050 - INFO - Found context match: 0x10871BE -> 0x10D29BE (diff: +309248)
+2025-08-06 13:00:07,050 - INFO - ✓ Validated patch location 0x10D29BE
+2025-08-06 13:00:07,050 - INFO - ✓ Applied patch: 0x10871BE -> 0x10D29BE
+2025-08-06 13:00:07,050 - INFO - Processing patch at 0x10872C0: 0xEB -> 0x03
+2025-08-06 13:00:07,959 - INFO - Found context match: 0x10872C0 -> 0x10D2AC0 (diff: +309248)
+2025-08-06 13:00:07,959 - INFO - ✓ Validated patch location 0x10D2AC0
+2025-08-06 13:00:07,959 - INFO - ✓ Applied patch: 0x10872C0 -> 0x10D2AC0
+2025-08-06 13:00:07,959 - INFO - Processing patch at 0x10872C1: 0xFF -> 0x45
+2025-08-06 13:00:08,868 - INFO - Found context match: 0x10872C1 -> 0x10D2AC1 (diff: +309248)
+2025-08-06 13:00:08,868 - INFO - ✓ Validated patch location 0x10D2AC1
+2025-08-06 13:00:08,868 - INFO - ✓ Applied patch: 0x10872C1 -> 0x10D2AC1
+2025-08-06 13:00:08,868 - INFO - Processing patch at 0x10872C2: 0x01 -> 0x00
+2025-08-06 13:00:09,779 - INFO - Found context match: 0x10872C2 -> 0x10D2AC2 (diff: +309248)
+2025-08-06 13:00:09,779 - INFO - ✓ Validated patch location 0x10D2AC2
+2025-08-06 13:00:09,779 - INFO - ✓ Applied patch: 0x10872C2 -> 0x10D2AC2
+2025-08-06 13:00:09,779 - INFO - Processing patch at 0x10872F8: 0x54 -> 0x12
+2025-08-06 13:00:10,690 - INFO - Found context match: 0x10872F8 -> 0x10D2AF8 (diff: +309248)
+2025-08-06 13:00:10,690 - INFO - ✓ Validated patch location 0x10D2AF8
+2025-08-06 13:00:10,690 - INFO - ✓ Applied patch: 0x10872F8 -> 0x10D2AF8
+2025-08-06 13:00:10,690 - INFO - Processing patch at 0x10872F9: 0xFE -> 0x46
+2025-08-06 13:00:11,648 - INFO - Found context match: 0x10872F9 -> 0x10D2AF9 (diff: +309248)
+2025-08-06 13:00:11,648 - INFO - ✓ Validated patch location 0x10D2AF9
+2025-08-06 13:00:11,648 - INFO - ✓ Applied patch: 0x10872F9 -> 0x10D2AF9
+2025-08-06 13:00:11,648 - INFO - Processing patch at 0x10872FA: 0x01 -> 0x00
+2025-08-06 13:00:12,555 - INFO - Found context match: 0x10872FA -> 0x10D2AFA (diff: +309248)
+2025-08-06 13:00:12,555 - INFO - ✓ Validated patch location 0x10D2AFA
+2025-08-06 13:00:12,555 - INFO - ✓ Applied patch: 0x10872FA -> 0x10D2AFA
+2025-08-06 13:00:12,555 - INFO - Processing patch at 0x10886FC: 0x54 -> 0x12
+2025-08-06 13:00:13,464 - INFO - Found context match: 0x10886FC -> 0x10D3EFC (diff: +309248)
+2025-08-06 13:00:13,464 - INFO - ✓ Validated patch location 0x10D3EFC
+2025-08-06 13:00:13,464 - INFO - ✓ Applied patch: 0x10886FC -> 0x10D3EFC
+2025-08-06 13:00:13,464 - INFO - Processing patch at 0x10886FD: 0xFE -> 0x46
+2025-08-06 13:00:14,373 - INFO - Found context match: 0x10886FD -> 0x10D3EFD (diff: +309248)
+2025-08-06 13:00:14,374 - INFO - ✓ Validated patch location 0x10D3EFD
+2025-08-06 13:00:14,374 - INFO - ✓ Applied patch: 0x10886FD -> 0x10D3EFD
+2025-08-06 13:00:14,374 - INFO - Processing patch at 0x10886FE: 0x01 -> 0x00
+2025-08-06 13:00:15,285 - INFO - Found context match: 0x10886FE -> 0x10D3EFE (diff: +309248)
+2025-08-06 13:00:15,285 - INFO - ✓ Validated patch location 0x10D3EFE
+2025-08-06 13:00:15,285 - INFO - ✓ Applied patch: 0x10886FE -> 0x10D3EFE
+2025-08-06 13:00:15,285 - INFO - Processing patch at 0x1088B14: 0x54 -> 0x12
+2025-08-06 13:00:16,199 - INFO - Found context match: 0x1088B14 -> 0x10D4314 (diff: +309248)
+2025-08-06 13:00:16,199 - INFO - ✓ Validated patch location 0x10D4314
+2025-08-06 13:00:16,199 - INFO - ✓ Applied patch: 0x1088B14 -> 0x10D4314
+2025-08-06 13:00:16,199 - INFO - Processing patch at 0x1088B15: 0xFE -> 0x46
+2025-08-06 13:00:17,106 - INFO - Found context match: 0x1088B15 -> 0x10D4315 (diff: +309248)
+2025-08-06 13:00:17,106 - INFO - ✓ Validated patch location 0x10D4315
+2025-08-06 13:00:17,106 - INFO - ✓ Applied patch: 0x1088B15 -> 0x10D4315
+2025-08-06 13:00:17,106 - INFO - Processing patch at 0x1088B16: 0x01 -> 0x00
+2025-08-06 13:00:18,018 - INFO - Found context match: 0x1088B16 -> 0x10D4316 (diff: +309248)
+2025-08-06 13:00:18,018 - INFO - ✓ Validated patch location 0x10D4316
+2025-08-06 13:00:18,018 - INFO - ✓ Applied patch: 0x1088B16 -> 0x10D4316
+2025-08-06 13:00:18,018 - INFO - Processing patch at 0x108E600: 0x54 -> 0x12
+2025-08-06 13:00:18,928 - INFO - Found context match: 0x108E600 -> 0x10D9E00 (diff: +309248)
+2025-08-06 13:00:18,928 - INFO - ✓ Validated patch location 0x10D9E00
+2025-08-06 13:00:18,928 - INFO - ✓ Applied patch: 0x108E600 -> 0x10D9E00
+2025-08-06 13:00:18,928 - INFO - Processing patch at 0x108E601: 0xFE -> 0x46
+2025-08-06 13:00:19,886 - INFO - Found context match: 0x108E601 -> 0x10D9E01 (diff: +309248)
+2025-08-06 13:00:19,886 - INFO - ✓ Validated patch location 0x10D9E01
+2025-08-06 13:00:19,886 - INFO - ✓ Applied patch: 0x108E601 -> 0x10D9E01
+2025-08-06 13:00:19,886 - INFO - Processing patch at 0x108E602: 0x01 -> 0x00
+2025-08-06 13:00:20,799 - INFO - Found context match: 0x108E602 -> 0x10D9E02 (diff: +309248)
+2025-08-06 13:00:20,800 - INFO - ✓ Validated patch location 0x10D9E02
+2025-08-06 13:00:20,800 - INFO - ✓ Applied patch: 0x108E602 -> 0x10D9E02
+2025-08-06 13:00:20,800 - INFO - Processing patch at 0x10A1FFC: 0x73 -> 0x60
+2025-08-06 13:00:21,760 - INFO - Found context match: 0x10A1FFC -> 0x10ED7FC (diff: +309248)
+2025-08-06 13:00:21,760 - INFO - ✓ Validated patch location 0x10ED7FC
+2025-08-06 13:00:21,760 - INFO - ✓ Applied patch: 0x10A1FFC -> 0x10ED7FC
+2025-08-06 13:00:21,760 - INFO - Processing patch at 0x10A1FFD: 0xDA -> 0x8B
+2025-08-06 13:00:22,719 - INFO - Found context match: 0x10A1FFD -> 0x10ED7FD (diff: +309248)
+2025-08-06 13:00:22,719 - INFO - ✓ Validated patch location 0x10ED7FD
+2025-08-06 13:00:22,719 - INFO - ✓ Applied patch: 0x10A1FFD -> 0x10ED7FD
+2025-08-06 13:00:22,720 - INFO - Processing patch at 0x10A1FFE: 0xC4 -> 0xB3
+2025-08-06 13:00:23,682 - INFO - Found context match: 0x10A1FFE -> 0x10ED7FE (diff: +309248)
+2025-08-06 13:00:23,682 - INFO - ✓ Validated patch location 0x10ED7FE
+2025-08-06 13:00:23,682 - INFO - ✓ Applied patch: 0x10A1FFE -> 0x10ED7FE
+2025-08-06 13:00:23,708 - INFO - ✓ Mixed file saved: /workspace/mixed/FDAT.T
+2025-08-06 13:00:23,708 - INFO - === PATCH SUMMARY ===
+2025-08-06 13:00:23,708 - INFO - Total patches: 71
+2025-08-06 13:00:23,708 - INFO - Successful patches: 71
+2025-08-06 13:00:23,709 - INFO - Failed patches: 0
+2025-08-06 13:00:23,709 - INFO - Success rate: 100.0%
+2025-08-06 13:00:23,709 - INFO - 🎉 All patches applied successfully!
+2025-08-06 13:00:23,709 - INFO - === Smart Patch Mixer Completed ===

--- a/smart_patch_mixer.py
+++ b/smart_patch_mixer.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Smart Patch Mixer for ROM Files
+Intelligently applies True Analog patches to undub version by finding correct offsets
+using code context matching instead of assuming same offsets.
+"""
+
+import os
+import logging
+from datetime import datetime
+
+def setup_logging():
+    """Setup logging to both console and file"""
+    log_filename = f"patch_mixer_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+    
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.FileHandler(log_filename),
+            logging.StreamHandler()
+        ]
+    )
+    return log_filename
+
+def find_file_in_folder(folder_path):
+    """Find the first file in a folder and ensure only one file exists"""
+    if not os.path.exists(folder_path):
+        return None, None, "Folder does not exist"
+    
+    files = []
+    for item in os.listdir(folder_path):
+        item_path = os.path.join(folder_path, item)
+        if os.path.isfile(item_path):
+            files.append((item_path, item))
+    
+    if len(files) == 0:
+        return None, None, "No files found"
+    elif len(files) > 1:
+        file_list = ", ".join([f[1] for f in files])
+        return None, None, f"Multiple files found: {file_list}. Please ensure only one file per folder."
+    else:
+        return files[0][0], files[0][1], None
+
+def find_context_match(original_data, undub_data, target_offset, context_size=16):
+    """
+    Find the corresponding location in undub by matching surrounding code context
+    """
+    # Extract context around the target offset in original
+    start = max(0, target_offset - context_size)
+    end = min(len(original_data), target_offset + context_size)
+    original_context = original_data[start:end]
+    
+    # Search for this context in undub
+    for i in range(len(undub_data) - len(original_context) + 1):
+        if undub_data[i:i + len(original_context)] == original_context:
+            # Found matching context, calculate the corresponding offset
+            offset_diff = i - start
+            new_offset = target_offset + offset_diff
+            
+            logging.info(f"Found context match: 0x{target_offset:06X} -> 0x{new_offset:06X} (diff: +{offset_diff})")
+            return new_offset
+    
+    logging.warning(f"Could not find context match for offset 0x{target_offset:06X}")
+    return None
+
+def validate_patch_location(original_data, undub_data, true_analog_data, original_offset, undub_offset):
+    """
+    Validate that the patch location is correct by checking surrounding bytes
+    """
+    # Check a few bytes before and after the patch location
+    check_size = 8
+    start = max(0, original_offset - check_size)
+    end = min(len(original_data), original_offset + check_size)
+    
+    original_section = original_data[start:end]
+    undub_section = undub_data[undub_offset - (original_offset - start):undub_offset + (end - original_offset)]
+    
+    if len(undub_section) != len(original_section):
+        logging.error(f"Section size mismatch at 0x{original_offset:06X}")
+        return False
+    
+    # Check if the sections match (they should, since we found them by context)
+    if undub_section != original_section:
+        logging.error(f"Section content mismatch at 0x{original_offset:06X}")
+        return False
+    
+    logging.info(f"✓ Validated patch location 0x{undub_offset:06X}")
+    return True
+
+def apply_smart_patch():
+    """Main function to apply True Analog patches to undub with correct offsets"""
+    base_path = os.path.dirname(os.path.abspath(__file__))
+    log_filename = setup_logging()
+    
+    logging.info("=== Smart Patch Mixer Started ===")
+    logging.info(f"Log file: {log_filename}")
+    
+    # Check if mixed folder is empty
+    mixed_folder = os.path.join(base_path, 'mixed')
+    if os.path.exists(mixed_folder):
+        mixed_files = [f for f in os.listdir(mixed_folder) if os.path.isfile(os.path.join(mixed_folder, f))]
+        if mixed_files:
+            logging.error(f"Mixed folder is not empty. Found files: {', '.join(mixed_files)}")
+            logging.error("Please remove files from the mixed folder before running.")
+            return False
+    
+    # Find files in each folder
+    original_path, original_filename, error = find_file_in_folder(os.path.join(base_path, 'original'))
+    if error:
+        logging.error(f"Error in 'original' folder: {error}")
+        return False
+    
+    true_analog_path, true_analog_filename, error = find_file_in_folder(os.path.join(base_path, 'true analog'))
+    if error:
+        logging.error(f"Error in 'true analog' folder: {error}")
+        return False
+    
+    undub_path, undub_filename, error = find_file_in_folder(os.path.join(base_path, 'undub'))
+    if error:
+        logging.error(f"Error in 'undub' folder: {error}")
+        return False
+    
+    logging.info(f"Found files:")
+    logging.info(f"  Original: {original_filename}")
+    logging.info(f"  True Analog: {true_analog_filename}")
+    logging.info(f"  Undub: {undub_filename}")
+    
+    # Load files
+    logging.info("Loading files...")
+    try:
+        with open(original_path, 'rb') as f:
+            original_data = f.read()
+        with open(true_analog_path, 'rb') as f:
+            true_analog_data = f.read()
+        with open(undub_path, 'rb') as f:
+            undub_data = f.read()
+        
+        logging.info(f"Original: {len(original_data)} bytes")
+        logging.info(f"True Analog: {len(true_analog_data)} bytes")
+        logging.info(f"Undub: {len(undub_data)} bytes")
+    except Exception as e:
+        logging.error(f"Error loading files: {e}")
+        return False
+    
+    # Find True Analog differences
+    logging.info("Analyzing True Analog differences...")
+    ta_diffs = []
+    for i in range(min(len(original_data), len(true_analog_data))):
+        if original_data[i] != true_analog_data[i]:
+            ta_diffs.append((i, original_data[i], true_analog_data[i]))
+    
+    logging.info(f"Found {len(ta_diffs)} True Analog differences")
+    
+    # Create mixed file starting with undub
+    logging.info("Creating mixed file from undub base...")
+    mixed_data = bytearray(undub_data)
+    
+    # Apply True Analog patches with adjusted offsets
+    successful_patches = 0
+    failed_patches = 0
+    
+    for original_offset, original_byte, new_byte in ta_diffs:
+        logging.info(f"Processing patch at 0x{original_offset:06X}: 0x{original_byte:02X} -> 0x{new_byte:02X}")
+        
+        # Find corresponding location in undub
+        undub_offset = find_context_match(original_data, undub_data, original_offset)
+        
+        if undub_offset is None:
+            logging.error(f"Failed to find location for patch at 0x{original_offset:06X}")
+            failed_patches += 1
+            continue
+        
+        # Validate the location
+        if not validate_patch_location(original_data, undub_data, true_analog_data, original_offset, undub_offset):
+            logging.error(f"Validation failed for patch at 0x{original_offset:06X}")
+            failed_patches += 1
+            continue
+        
+        # Apply the patch
+        if undub_offset < len(mixed_data):
+            mixed_data[undub_offset] = new_byte
+            logging.info(f"✓ Applied patch: 0x{original_offset:06X} -> 0x{undub_offset:06X}")
+            successful_patches += 1
+        else:
+            logging.error(f"Offset 0x{undub_offset:06X} is out of bounds")
+            failed_patches += 1
+    
+    # Save mixed file
+    if not os.path.exists(mixed_folder):
+        os.makedirs(mixed_folder)
+    
+    mixed_filename = undub_filename  # Use same name as undub
+    mixed_path = os.path.join(mixed_folder, mixed_filename)
+    
+    try:
+        with open(mixed_path, 'wb') as f:
+            f.write(mixed_data)
+        logging.info(f"✓ Mixed file saved: {mixed_path}")
+    except Exception as e:
+        logging.error(f"Error saving mixed file: {e}")
+        return False
+    
+    # Summary
+    logging.info("=== PATCH SUMMARY ===")
+    logging.info(f"Total patches: {len(ta_diffs)}")
+    logging.info(f"Successful patches: {successful_patches}")
+    logging.info(f"Failed patches: {failed_patches}")
+    logging.info(f"Success rate: {successful_patches/len(ta_diffs)*100:.1f}%")
+    
+    if failed_patches == 0:
+        logging.info("🎉 All patches applied successfully!")
+    else:
+        logging.warning(f"⚠ {failed_patches} patches failed. Check log for details.")
+    
+    logging.info("=== Smart Patch Mixer Completed ===")
+    return True
+
+if __name__ == "__main__":
+    apply_smart_patch()


### PR DESCRIPTION
Create a Python script to apply True Analog patches to undub ROMs by dynamically finding correct offsets.

The undub ROM file is larger due to additional audio data, which shifts code offsets. This script uses context matching to locate the correct patch application points in the undub file, ensuring patch integrity despite the offset changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5030860-c56b-4401-bd18-3a6b5ebc34d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5030860-c56b-4401-bd18-3a6b5ebc34d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

